### PR TITLE
Pyvista read the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,8 +15,6 @@ build:
     # rust: "1.64"
     # golang: "1.19"
     #
-  commands:
-    - pip install vtk-osmesa --index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple
 
 # Specify that the extra dependcies for docs listed in the
 # pyproject.toml are installed.
@@ -26,6 +24,7 @@ python:
       path: .
       extra_requirements:
         - docs
+    - requirements: docs/requirements.txt
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -35,10 +34,3 @@ sphinx:
 # formats:
 #    - pdf
 #    - epub
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+--index-url https://gitlab.kitware.com/api/v4/projects/13/packages/pypi/simple
+vtk-osmesa


### PR DESCRIPTION
Read the docs was thowing the following error after adding the dendrite example that includes interactive pyvista plots:

`2024-09-11 08:08:32.876 ( 111.134s) [    7F7B62A5EC40]vtkXOpenGLRenderWindow.:456    ERR| vtkXOpenGLRenderWindow (0x55be73c2ed20): bad X server connection. DISPLAY=`

Checking the [pyvista github actions](https://github.com/pyvista/pyvista/blob/main/.github/workflows/docs.yml) revealed that they are using a special version of vtk with osmesa to avoid this issue.
They also set some environment variables but those don't seem to be necessary in our case.