### PR TITLE
Str and repr for classes

### DIFF
--- a/src/splinebox/basis_functions.py
+++ b/src/splinebox/basis_functions.py
@@ -138,6 +138,12 @@ class B1(BasisFunction):
     def __init__(self):
         super().__init__(False, 2)
 
+    def __str__(self):
+        return "B1"
+
+    def __repr__(self):
+        return "B1()"
+
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
     def _func(t):  # pragma: no cover
@@ -194,6 +200,12 @@ class B2(BasisFunction):
 
     def __init__(self):
         super().__init__(False, 3)
+
+    def __str__(self):
+        return "B2"
+
+    def __repr__(self):
+        return "B2()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -254,6 +266,12 @@ class B3(BasisFunction):
 
     def __init__(self):
         super().__init__(False, 4)
+
+    def __str__(self):
+        return "B3"
+
+    def __repr__(self):
+        return "B3()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -387,6 +405,12 @@ class Exponential(BasisFunction):
     def __init__(self, M):
         super().__init__(False, 3)
         self.M = M
+
+    def __str__(self):
+        return "Exponential"
+
+    def __repr__(self):
+        return f"Exponential(M={self.M})"
 
     def _func(self, t):
         return self.__func(t, self.support / 2, self.M)
@@ -574,6 +598,12 @@ class CatmullRom(BasisFunction):
     def __init__(self):
         super().__init__(False, 4)
 
+    def __str__(self):
+        return "CatmullRom"
+
+    def __repr__(self):
+        return "CatmullRom()"
+
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
     def _func(t):  # pragma: no cover
@@ -640,6 +670,12 @@ class CubicHermite(BasisFunction):
 
     def __init__(self):
         super().__init__(True, 2)
+
+    def __str__(self):
+        return "CubicHermite"
+
+    def __repr__(self):
+        return "CubicHermite()"
 
     def _func(self, t):
         return np.array([self.h31(t), self.h32(t)])
@@ -831,6 +867,12 @@ class ExponentialHermite(BasisFunction):
     def __init__(self, M):
         super().__init__(True, 2)
         self.M = M
+
+    def __str__(self):
+        return "ExponentialHermite"
+
+    def __repr__(self):
+        return f"ExponentialHermite(M={self.M})"
 
     def _func(self, t):
         return np.array([self._he31(t, self.M), self._he32(t, self.M)])

--- a/src/splinebox/basis_functions.py
+++ b/src/splinebox/basis_functions.py
@@ -32,6 +32,19 @@ class BasisFunction:
         self.multigenerator = multigenerator
         self.support = support
 
+    def __str__(self):
+        return "BasisFunction"
+
+    def __repr__(self):
+        return f"splinebox.basis_functions.BasisFunction(multigenerator={self.multigenerator}, support={self.support})"
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, type(self))
+            and other.multigenerator == self.multigenerator
+            and other.support == self.support
+        )
+
     def eval(self, t, derivative=0):
         """
         Evaluate the function at position(s) `t`.
@@ -142,7 +155,7 @@ class B1(BasisFunction):
         return "B1"
 
     def __repr__(self):
-        return "B1()"
+        return "splinebox.basis_functions.B1()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -205,7 +218,7 @@ class B2(BasisFunction):
         return "B2"
 
     def __repr__(self):
-        return "B2()"
+        return "splinebox.basis_functions.B2()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -271,7 +284,7 @@ class B3(BasisFunction):
         return "B3"
 
     def __repr__(self):
-        return "B3()"
+        return "splinebox.basis_functions.B3()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -410,7 +423,10 @@ class Exponential(BasisFunction):
         return "Exponential"
 
     def __repr__(self):
-        return f"Exponential(M={self.M})"
+        return f"splinebox.basis_functions.Exponential(M={self.M})"
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and other.M == self.M
 
     def _func(self, t):
         return self.__func(t, self.support / 2, self.M)
@@ -602,7 +618,7 @@ class CatmullRom(BasisFunction):
         return "CatmullRom"
 
     def __repr__(self):
-        return "CatmullRom()"
+        return "splinebox.basis_functions.CatmullRom()"
 
     @staticmethod
     @numba.vectorize([numba.float64(numba.float64)], nopython=True, cache=True)
@@ -675,7 +691,7 @@ class CubicHermite(BasisFunction):
         return "CubicHermite"
 
     def __repr__(self):
-        return "CubicHermite()"
+        return "splinebox.basis_functions.CubicHermite()"
 
     def _func(self, t):
         return np.array([self.h31(t), self.h32(t)])
@@ -872,7 +888,10 @@ class ExponentialHermite(BasisFunction):
         return "ExponentialHermite"
 
     def __repr__(self):
-        return f"ExponentialHermite(M={self.M})"
+        return f"splinebox.basis_functions.ExponentialHermite(M={self.M})"
+
+    def __eq__(self, other):
+        return isinstance(other, type(self)) and other.M == self.M
 
     def _func(self, t):
         return np.array([self._he31(t, self.M), self._he32(t, self.M)])

--- a/src/splinebox/basis_functions.py
+++ b/src/splinebox/basis_functions.py
@@ -36,7 +36,7 @@ class BasisFunction:
         return "BasisFunction"
 
     def __repr__(self):
-        return f"splinebox.basis_functions.BasisFunction(multigenerator={self.multigenerator}, support={self.support})"
+        return f"splinebox.basis_functions.BasisFunction(multigenerator={repr(self.multigenerator)}, support={repr(self.support)})"
 
     def __eq__(self, other):
         return (
@@ -423,7 +423,7 @@ class Exponential(BasisFunction):
         return "Exponential"
 
     def __repr__(self):
-        return f"splinebox.basis_functions.Exponential(M={self.M})"
+        return f"splinebox.basis_functions.Exponential(M={repr(self.M)})"
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and other.M == self.M
@@ -888,7 +888,7 @@ class ExponentialHermite(BasisFunction):
         return "ExponentialHermite"
 
     def __repr__(self):
-        return f"splinebox.basis_functions.ExponentialHermite(M={self.M})"
+        return f"splinebox.basis_functions.ExponentialHermite(M={repr(self.M)})"
 
     def __eq__(self, other):
         return isinstance(other, type(self)) and other.M == self.M

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -82,6 +82,25 @@ class Spline:
         if self.control_points is None:
             raise RuntimeError(self._no_control_points_msg)
 
+    def __str__(self):
+        closed_str = "closed" if self.closed else "open"
+        if self.control_points is None:
+            return f"uninitialized {closed_str} {self.basis_function} spline with {self.M} knots"
+        else:
+            nD = 1 if self.control_points.ndim == 1 else self.control_points.shape[1]
+            return f"{closed_str} {nD}D {self.basis_function} spline with {self.M} knots"
+
+    def __repr__(self):
+        return f"splinebox.spline_curves.Spline(M={repr(self.M)}, basis_function={repr(self.basis_function)}, closed={repr(self.closed)}, control_points=np.{repr(self.control_points)})"
+
+    def __eq__(self, other):
+        return (
+            self.M == other.M
+            and self.basis_function == other.basis_function
+            and self.closed == other.closed
+            and np.all(self.control_points == other.control_points)
+        )
+
     @property
     def control_points(self):
         """
@@ -735,6 +754,12 @@ class HermiteSpline(Spline):
         self._check_control_points()
         if self.tangents is None:
             raise RuntimeError(self._no_tangents_msg)
+
+    def __repr__(self):
+        return f"splinebox.spline_curves.HermiteSpline(M={repr(self.M)}, basis_function={repr(self.basis_function)}, closed={repr(self.closed)}, control_points=np.{repr(self.control_points)}, tangents=np.{repr(self.tangents)})"
+
+    def __eq__(self, other):
+        return super().__eq__(other) and np.all(self.tangents == other.tangents)
 
     @property
     def tangents(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,3 +275,13 @@ def n_points(request):
 def points(codomain_dimensionality, n_points):
     rng = np.random.default_rng(seed=5544)
     return np.squeeze(rng.random((n_points, codomain_dimensionality)))
+
+
+@pytest.fixture(params=[False, True])
+def multigenerator(request):
+    return request.param
+
+
+@pytest.fixture(params=[2, 3, 4])
+def support(request):
+    return request.param

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -136,14 +136,34 @@ def test_partition_of_unity(basis_function):
 
 def test_repr(basis_function):
     assert eval(repr(basis_function)) == basis_function
-    if isinstance(basis_function, splinebox.basis_functions.Exponential):
-        assert eval(repr(basis_function)) != splinebox.basis_functions.Exponential(M=basis_function.M + 1)
+
+
+def test_eq(basis_function):
+    if isinstance(basis_function, splinebox.basis_functions.B1):
+        assert basis_function == splinebox.basis_functions.B1()
+    elif isinstance(basis_function, splinebox.basis_functions.B2):
+        assert basis_function == splinebox.basis_functions.B2()
+    elif isinstance(basis_function, splinebox.basis_functions.B3):
+        assert basis_function == splinebox.basis_functions.B3()
+    elif isinstance(basis_function, splinebox.basis_functions.Exponential):
+        assert basis_function == splinebox.basis_functions.Exponential(M=basis_function.M)
+        assert basis_function != splinebox.basis_functions.Exponential(M=basis_function.M + 1)
+    elif isinstance(basis_function, splinebox.basis_functions.CatmullRom):
+        assert basis_function == splinebox.basis_functions.CatmullRom()
+    elif isinstance(basis_function, splinebox.basis_functions.CubicHermite):
+        assert basis_function == splinebox.basis_functions.CubicHermite()
     elif isinstance(basis_function, splinebox.basis_functions.ExponentialHermite):
-        assert eval(repr(basis_function)) != splinebox.basis_functions.ExponentialHermite(M=basis_function.M + 1)
+        assert basis_function == splinebox.basis_functions.ExponentialHermite(M=basis_function.M)
+        assert basis_function != splinebox.basis_functions.ExponentialHermite(M=basis_function.M + 1)
 
 
 def test_repr_base_class(multigenerator, support):
     basis_function = splinebox.basis_functions.BasisFunction(multigenerator, support)
     assert eval(repr(basis_function)) == basis_function
-    assert eval(repr(basis_function)) != splinebox.basis_functions.BasisFunction(not multigenerator, support)
-    assert eval(repr(basis_function)) != splinebox.basis_functions.BasisFunction(multigenerator, support + 1)
+
+
+def test_eq_base_blass(multigenerator, support):
+    basis_function = splinebox.basis_functions.BasisFunction(multigenerator, support)
+    assert basis_function == splinebox.basis_functions.BasisFunction(multigenerator, support)
+    assert basis_function != splinebox.basis_functions.BasisFunction(not multigenerator, support)
+    assert basis_function != splinebox.basis_functions.BasisFunction(multigenerator, support + 1)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -132,3 +132,18 @@ def test_partition_of_unity(basis_function):
             vals = vals[:, 0]
         summed += vals
     assert np.allclose(summed, np.ones_like(summed))
+
+
+def test_repr(basis_function):
+    assert eval(repr(basis_function)) == basis_function
+    if isinstance(basis_function, splinebox.basis_functions.Exponential):
+        assert eval(repr(basis_function)) != splinebox.basis_functions.Exponential(M=basis_function.M + 1)
+    elif isinstance(basis_function, splinebox.basis_functions.ExponentialHermite):
+        assert eval(repr(basis_function)) != splinebox.basis_functions.ExponentialHermite(M=basis_function.M + 1)
+
+
+def test_repr_base_class(multigenerator, support):
+    basis_function = splinebox.basis_functions.BasisFunction(multigenerator, support)
+    assert eval(repr(basis_function)) == basis_function
+    assert eval(repr(basis_function)) != splinebox.basis_functions.BasisFunction(not multigenerator, support)
+    assert eval(repr(basis_function)) != splinebox.basis_functions.BasisFunction(multigenerator, support + 1)

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -162,8 +162,17 @@ def test_repr_base_class(multigenerator, support):
     assert eval(repr(basis_function)) == basis_function
 
 
-def test_eq_base_blass(multigenerator, support):
+def test_eq_base_class(multigenerator, support):
     basis_function = splinebox.basis_functions.BasisFunction(multigenerator, support)
     assert basis_function == splinebox.basis_functions.BasisFunction(multigenerator, support)
     assert basis_function != splinebox.basis_functions.BasisFunction(not multigenerator, support)
     assert basis_function != splinebox.basis_functions.BasisFunction(multigenerator, support + 1)
+
+
+def test_str(basis_function):
+    assert isinstance(str(basis_function), str)
+
+
+def test_str_base_class(multigenerator, support):
+    basis_function = splinebox.basis_functions.BasisFunction(multigenerator, support)
+    assert isinstance(str(basis_function), str)

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -633,3 +633,7 @@ def test_eq_spline(spline_curve, basis_function, closed, coeff_gen, is_hermite_s
             M=spline.M + 1, basis_function=spline.basis_function, closed=spline.closed
         )
     assert spline != other
+
+
+def test_str(initialized_spline_curve):
+    assert isinstance(str(initialized_spline_curve), str)

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -585,3 +585,51 @@ def test_normal():
 
         # Check that they are normal vectors
         assert np.allclose(np.linalg.norm(normals, axis=1), np.ones(len(t)))
+
+
+def test_repr(initialized_spline_curve, is_hermite_spline):
+    spline = initialized_spline_curve
+    # The rounding is necessary because the precision is limited in the string representation
+    spline.control_points = np.round(spline.control_points, decimals=np.get_printoptions()["precision"])
+    if is_hermite_spline(spline):
+        spline.tangents = np.round(spline.tangents, decimals=np.get_printoptions()["precision"])
+    assert eval(repr(spline)) == spline
+
+
+def test_eq_spline(spline_curve, basis_function, closed, coeff_gen, is_hermite_spline):
+    spline = spline_curve
+    basis_function = basis_function
+    if is_hermite_spline(spline):
+        other = splinebox.spline_curves.HermiteSpline(
+            M=spline.M, basis_function=basis_function, closed=closed, control_points=spline.control_points
+        )
+    else:
+        other = splinebox.spline_curves.Spline(
+            M=spline.M, basis_function=basis_function, closed=closed, control_points=spline.control_points
+        )
+    if spline.basis_function != basis_function or spline.closed != closed:
+        assert spline != other
+    else:
+        assert spline == other
+
+        spline.control_points = coeff_gen(spline.M, spline.basis_function.support, spline.closed)
+        if is_hermite_spline(spline):
+            spline.tangents = coeff_gen(spline.M, spline.basis_function.support, spline.closed)
+        assert spline != other
+
+        other.control_points = spline.control_points
+        if is_hermite_spline(spline) and is_hermite_spline(other):
+            # The tangents should not be equal yet
+            assert spline != other
+            other.tangents = spline.tangents
+        assert spline == other
+
+    if is_hermite_spline(spline):
+        other = splinebox.spline_curves.HermiteSpline(
+            M=spline.M + 1, basis_function=spline.basis_function, closed=spline.closed
+        )
+    else:
+        other = splinebox.spline_curves.Spline(
+            M=spline.M + 1, basis_function=spline.basis_function, closed=spline.closed
+        )
+    assert spline != other


### PR DESCRIPTION
Implemented `__str__`, `__repr__`, and `__eq__` for `BasisFunction`, `B1`, `B2`, `B3`, `Exponential`, `CatmullRom`, `CubicHermite`, `ExponentialHermite`, `Spline`, and `HermiteSpline`.