### PR TITLE
Implement second derivative for Hermite splines

### DIFF
--- a/docs/pyplots/plot_b1.py
+++ b/docs/pyplots/plot_b1.py
@@ -6,7 +6,7 @@ fig, axes = plt.subplots(2, 1, sharex=True)
 
 b1 = splinebox.basis_functions.B1()
 
-t = np.linspace(-2, 2, 100)
+t = np.linspace(-2, 2, 1000)
 
 b1_0th = b1.eval(t)
 b1_1st = b1.eval(t, derivative=1)

--- a/docs/pyplots/plot_b2.py
+++ b/docs/pyplots/plot_b2.py
@@ -6,7 +6,7 @@ fig, axes = plt.subplots(3, 1, sharex=True)
 
 b2 = splinebox.basis_functions.B2()
 
-t = np.linspace(-2, 2, 100)
+t = np.linspace(-2, 2, 1000)
 
 b2_0th = b2.eval(t)
 b2_1st = b2.eval(t, derivative=1)

--- a/docs/pyplots/plot_b3.py
+++ b/docs/pyplots/plot_b3.py
@@ -6,7 +6,7 @@ fig, axes = plt.subplots(3, 1, sharex=True)
 
 b3 = splinebox.basis_functions.B3()
 
-t = np.linspace(-3, 3, 100)
+t = np.linspace(-3, 3, 1000)
 
 b3_0th = b3.eval(t)
 b3_1st = b3.eval(t, derivative=1)

--- a/docs/pyplots/plot_catmullrom.py
+++ b/docs/pyplots/plot_catmullrom.py
@@ -6,7 +6,7 @@ fig, axes = plt.subplots(3, 1, sharex=True)
 
 basis = splinebox.basis_functions.CatmullRom()
 
-t = np.linspace(-3, 3, 100)
+t = np.linspace(-3, 3, 1000)
 
 basis_0th = basis.eval(t)
 basis_1st = basis.eval(t, derivative=1)

--- a/docs/pyplots/plot_cubichermite.py
+++ b/docs/pyplots/plot_cubichermite.py
@@ -2,26 +2,31 @@ import matplotlib.pyplot as plt
 import numpy as np
 import splinebox.basis_functions
 
-fig, axes = plt.subplots(2, 2, sharex=True)
+fig, axes = plt.subplots(3, 2, sharex=True)
 
 basis = splinebox.basis_functions.CubicHermite()
 
-t = np.linspace(-3, 3, 100)
+t = np.linspace(-3, 3, 1000)
 
 basis_0th = basis.eval(t)
 basis_1st = basis.eval(t, derivative=1)
+basis_2nd = basis.eval(t, derivative=2)
 
 fig.suptitle("Cubic Hermite basis function and its derivatives")
 axes[0][0].plot(t, basis_0th[0], label=r"$\Phi_1(t)$")
 axes[0][0].legend()
 axes[1][0].plot(t, basis_1st[0], label=r"$\frac{d\Phi_1}{dt}(t)$")
 axes[1][0].legend()
-axes[1][0].set_xlabel(r"$t$")
+axes[2][0].plot(t, basis_2nd[0], label=r"$\frac{d^2\Phi_1}{dt^2}(t)$")
+axes[2][0].legend()
+axes[2][0].set_xlabel(r"$t$")
 axes[0][1].plot(t, basis_0th[1], label=r"$\Phi_2(t)$")
 axes[0][1].legend()
 axes[1][1].plot(t, basis_1st[1], label=r"$\frac{d\Phi_2}{dt}(t)$")
 axes[1][1].legend()
-axes[1][1].set_xlabel(r"$t$")
+axes[2][1].plot(t, basis_2nd[1], label=r"$\frac{d^2\Phi_2}{dt^2}(t)$")
+axes[2][1].legend()
+axes[2][1].set_xlabel(r"$t$")
 plt.tight_layout()
 
 plt.show()

--- a/docs/pyplots/plot_exponential.py
+++ b/docs/pyplots/plot_exponential.py
@@ -7,7 +7,7 @@ fig, axes = plt.subplots(3, 1, sharex=True)
 M = 5
 basis = splinebox.basis_functions.Exponential(M=M)
 
-t = np.linspace(-3, 3, 100)
+t = np.linspace(-3, 3, 1000)
 
 basis_0th = basis.eval(t)
 basis_1st = basis.eval(t, derivative=1)

--- a/docs/pyplots/plot_exponentialhermite.py
+++ b/docs/pyplots/plot_exponentialhermite.py
@@ -2,27 +2,32 @@ import matplotlib.pyplot as plt
 import numpy as np
 import splinebox.basis_functions
 
-fig, axes = plt.subplots(2, 2, sharex=True)
+fig, axes = plt.subplots(3, 2, sharex=True)
 
 M = 5
 basis = splinebox.basis_functions.ExponentialHermite(M=M)
 
-t = np.linspace(-3, 3, 100)
+t = np.linspace(-3, 3, 1000)
 
 basis_0th = basis.eval(t)
 basis_1st = basis.eval(t, derivative=1)
+basis_2nd = basis.eval(t, derivative=2)
 
 fig.suptitle(f"Exponential Hermite basis function and its derivatives for $M={M}$")
 axes[0][0].plot(t, basis_0th[0], label=r"$\Phi_1(t)$")
 axes[0][0].legend()
 axes[1][0].plot(t, basis_1st[0], label=r"$\frac{d\Phi_1}{dt}(t)$")
 axes[1][0].legend()
-axes[1][0].set_xlabel(r"$t$")
+axes[2][0].plot(t, basis_2nd[0], label=r"$\frac{d^2\Phi_1}{dt^2}(t)$")
+axes[2][0].legend()
+axes[2][0].set_xlabel(r"$t$")
 axes[0][1].plot(t, basis_0th[1], label=r"$\Phi_2(t)$")
 axes[0][1].legend()
 axes[1][1].plot(t, basis_1st[1], label=r"$\frac{d\Phi_2}{dt}(t)$")
 axes[1][1].legend()
-axes[1][1].set_xlabel(r"$t$")
+axes[2][1].plot(t, basis_2nd[1], label=r"$\frac{d^2\Phi_2}{dt^2}(t)$")
+axes[2][1].legend()
+axes[2][1].set_xlabel(r"$t$")
 plt.tight_layout()
 
 plt.show()

--- a/docs/pyplots/plot_no_padding.py
+++ b/docs/pyplots/plot_no_padding.py
@@ -11,7 +11,7 @@ control_points = np.concatenate([np.zeros((1, 2)), control_points, np.zeros((1, 
 
 spline.control_points = control_points
 
-t = np.linspace(0, spline.M - 1, 100)
+t = np.linspace(0, spline.M - 1, 1000)
 vals = spline.eval(t)
 
 plt.figure(figsize=(6, 3))

--- a/docs/pyplots/plot_padding.py
+++ b/docs/pyplots/plot_padding.py
@@ -10,7 +10,7 @@ control_points = np.stack([np.cos(theta), np.sin(theta)], axis=-1)
 
 spline.control_points = control_points
 
-t = np.linspace(0, spline.M - 1, 100)
+t = np.linspace(0, spline.M - 1, 1000)
 vals = spline.eval(t)
 
 plt.figure(figsize=(6, 3))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,11 +201,7 @@ def not_differentiable_twice(is_spline):
         basis_function = obj.basis_function if is_spline(obj) else obj
         return isinstance(
             basis_function,
-            (
-                splinebox.basis_functions.B1,
-                splinebox.basis_functions.CubicHermite,
-                splinebox.basis_functions.ExponentialHermite,
-            ),
+            (splinebox.basis_functions.B1,),
         )
 
     return _not_differentiable_twice


### PR DESCRIPTION
In the original version, the `CubicHermite` and the `ExponentialHermite` basis functions where implemented as not twice differentiable, but they are in fact twice differentiable. They are just not C2. Since some of the non-Hermite basis functions are also not C2 but we have implemented the second derivative, we should also do this for the Hermite splines.

Even though the second derivatives are not continuous, having them will be useful to compute curvature and bending energy.