### PR TITLE
fix minor typo Spline.curvature docstring

### DIFF
--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -575,7 +575,7 @@ class Spline:
 
     def curvature(self, t):
         """
-        Compute the curcature of the spline at position(s) t.
+        Compute the curvature of the spline at position(s) t.
         For splines in 1 and 2 dimensions, the signed curvature
         is returned. Otherwise the unsigned curvature is returned.
 


### PR DESCRIPTION
Hello! This PR is just a minor typo fix for the `Spline.curvature` docstring