### PR TITLE
Deprecate eval

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -93,11 +93,11 @@ To sample an open spline with `M` knots:
 .. code-block:: python
 
     t = np.linspace(0, M-1, 100)
-    vals = spline.eval(t)
+    vals = spline(t)
 
 For a closed spline, continue past the last knot to sample all the way around:
 
 .. code-block:: python
 
     t = np.linspace(0, M, 100)
-    vals = spline.eval(t)
+    vals = spline(t)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ SplineBox
        spline.fit(data)
 
        t = np.linspace(0, M - 1, 1000)
-       vals = spline.eval(t)
+       vals = spline(t)
 
 .. raw:: html
 

--- a/docs/pyplots/plot_b1.py
+++ b/docs/pyplots/plot_b1.py
@@ -8,8 +8,8 @@ b1 = splinebox.basis_functions.B1()
 
 t = np.linspace(-2, 2, 1000)
 
-b1_0th = b1.eval(t)
-b1_1st = b1.eval(t, derivative=1)
+b1_0th = b1(t)
+b1_1st = b1(t, derivative=1)
 
 fig.suptitle("B1 basis function and its derivatives")
 axes[0].plot(t, b1_0th, label=r"$\Phi(t)$")

--- a/docs/pyplots/plot_b2.py
+++ b/docs/pyplots/plot_b2.py
@@ -8,9 +8,9 @@ b2 = splinebox.basis_functions.B2()
 
 t = np.linspace(-2, 2, 1000)
 
-b2_0th = b2.eval(t)
-b2_1st = b2.eval(t, derivative=1)
-b2_2nd = b2.eval(t, derivative=2)
+b2_0th = b2(t)
+b2_1st = b2(t, derivative=1)
+b2_2nd = b2(t, derivative=2)
 
 
 fig.suptitle("B2 basis function and its derivatives")

--- a/docs/pyplots/plot_b3.py
+++ b/docs/pyplots/plot_b3.py
@@ -8,9 +8,9 @@ b3 = splinebox.basis_functions.B3()
 
 t = np.linspace(-3, 3, 1000)
 
-b3_0th = b3.eval(t)
-b3_1st = b3.eval(t, derivative=1)
-b3_2nd = b3.eval(t, derivative=2)
+b3_0th = b3(t)
+b3_1st = b3(t, derivative=1)
+b3_2nd = b3(t, derivative=2)
 
 fig.suptitle("B3 basis function and its derivatives")
 axes[0].plot(t, b3_0th, label=r"$\Phi(t)$")

--- a/docs/pyplots/plot_catmullrom.py
+++ b/docs/pyplots/plot_catmullrom.py
@@ -8,9 +8,9 @@ basis = splinebox.basis_functions.CatmullRom()
 
 t = np.linspace(-3, 3, 1000)
 
-basis_0th = basis.eval(t)
-basis_1st = basis.eval(t, derivative=1)
-basis_2nd = basis.eval(t, derivative=2)
+basis_0th = basis(t)
+basis_1st = basis(t, derivative=1)
+basis_2nd = basis(t, derivative=2)
 
 fig.suptitle("Catmull Rom basis function and its derivatives")
 axes[0].plot(t, basis_0th, label=r"$\Phi(t)$")

--- a/docs/pyplots/plot_cubichermite.py
+++ b/docs/pyplots/plot_cubichermite.py
@@ -8,9 +8,9 @@ basis = splinebox.basis_functions.CubicHermite()
 
 t = np.linspace(-3, 3, 1000)
 
-basis_0th = basis.eval(t)
-basis_1st = basis.eval(t, derivative=1)
-basis_2nd = basis.eval(t, derivative=2)
+basis_0th = basis(t)
+basis_1st = basis(t, derivative=1)
+basis_2nd = basis(t, derivative=2)
 
 fig.suptitle("Cubic Hermite basis function and its derivatives")
 axes[0][0].plot(t, basis_0th[0], label=r"$\Phi_1(t)$")

--- a/docs/pyplots/plot_exponential.py
+++ b/docs/pyplots/plot_exponential.py
@@ -9,9 +9,9 @@ basis = splinebox.basis_functions.Exponential(M=M)
 
 t = np.linspace(-3, 3, 1000)
 
-basis_0th = basis.eval(t)
-basis_1st = basis.eval(t, derivative=1)
-basis_2nd = basis.eval(t, derivative=2)
+basis_0th = basis(t)
+basis_1st = basis(t, derivative=1)
+basis_2nd = basis(t, derivative=2)
 
 fig.suptitle(f"Exponential basis function and its derivatives for $M={M}$")
 axes[0].plot(t, basis_0th, label=r"$\Phi(t)$")

--- a/docs/pyplots/plot_exponentialhermite.py
+++ b/docs/pyplots/plot_exponentialhermite.py
@@ -9,9 +9,9 @@ basis = splinebox.basis_functions.ExponentialHermite(M=M)
 
 t = np.linspace(-3, 3, 1000)
 
-basis_0th = basis.eval(t)
-basis_1st = basis.eval(t, derivative=1)
-basis_2nd = basis.eval(t, derivative=2)
+basis_0th = basis(t)
+basis_1st = basis(t, derivative=1)
+basis_2nd = basis(t, derivative=2)
 
 fig.suptitle(f"Exponential Hermite basis function and its derivatives for $M={M}$")
 axes[0][0].plot(t, basis_0th[0], label=r"$\Phi_1(t)$")

--- a/docs/pyplots/plot_no_padding.py
+++ b/docs/pyplots/plot_no_padding.py
@@ -12,7 +12,7 @@ control_points = np.concatenate([np.zeros((1, 2)), control_points, np.zeros((1, 
 spline.control_points = control_points
 
 t = np.linspace(0, spline.M - 1, 1000)
-vals = spline.eval(t)
+vals = spline(t)
 
 plt.figure(figsize=(6, 3))
 plt.scatter(spline.control_points[1:-1, 0], spline.control_points[1:-1, 1], label="control points")

--- a/docs/pyplots/plot_padding.py
+++ b/docs/pyplots/plot_padding.py
@@ -11,7 +11,7 @@ control_points = np.stack([np.cos(theta), np.sin(theta)], axis=-1)
 spline.control_points = control_points
 
 t = np.linspace(0, spline.M - 1, 1000)
-vals = spline.eval(t)
+vals = spline(t)
 
 plt.figure(figsize=(6, 3))
 plt.scatter(spline.control_points[1:-1, 0], spline.control_points[1:-1, 1], label="control points")

--- a/docs/pyplots/plot_performance.py
+++ b/docs/pyplots/plot_performance.py
@@ -37,7 +37,7 @@ for repetition in range(n_repetitions + 1):
 
     t = np.linspace(0, M if closed else M - 1, nt)
     start_eval = time.perf_counter_ns()
-    spline.eval(t)
+    spline(t)
     stop_eval = time.perf_counter_ns()
     if repetition != 0:
         results.append(

--- a/examples/plot_3D_curvature.py
+++ b/examples/plot_3D_curvature.py
@@ -24,7 +24,7 @@ spline.control_points = np.random.rand(M + 2, 3)
 
 t = np.linspace(0, M - 1, M * 15)
 
-vals = spline.eval(t)
+vals = spline(t)
 
 # %%
 # 2. Curvature comb with pyvista

--- a/examples/plot_active_contours.py
+++ b/examples/plot_active_contours.py
@@ -45,7 +45,7 @@ edge_energy = scipy.interpolate.RectBivariateSpline(
 # We define an internal energy function to regularize the curvature of the spline.
 # The internal energy depends on the first and second derivatives of the spline.
 def internal_energy(spline, t, alpha, beta):
-    return 0.5 * (alpha * spline.eval(t, derivative=1) ** 2 + beta * spline.eval(t, derivative=2) ** 2)
+    return 0.5 * (alpha * spline(t, derivative=1) ** 2 + beta * spline(t, derivative=2) ** 2)
 
 
 # %%
@@ -67,7 +67,7 @@ spline = splinebox.spline_curves.Spline(M=M, basis_function=splinebox.basis_func
 spline.knots = knots
 
 t = np.linspace(0, M, 400)
-contour = spline.eval(t)
+contour = spline(t)
 plt.imshow(img)
 plt.scatter(knots[:, 1], knots[:, 0])
 plt.plot(contour[:, 1], contour[:, 0])
@@ -96,7 +96,7 @@ external_energies = []
 def energy_function(control_points, spline, t, alpha, beta):
     control_points = control_points.reshape((spline.M, -1))
     spline.control_points = control_points
-    contour = spline.eval(t)
+    contour = spline(t)
     contours.append(contour.copy())
 
     # Compute external energy from the edge map
@@ -121,9 +121,9 @@ result = scipy.optimize.minimize(
 # %%
 # Inorder to plot the spline as a smooth line, we have to evaluate it
 # more densly than just at the knots.
-samples = spline.eval(t)
+samples = spline(t)
 
-final_knots = spline.eval(np.arange(M))
+final_knots = spline(np.arange(M))
 
 # %%
 # Finaly, we can plot the result.

--- a/examples/plot_background.py
+++ b/examples/plot_background.py
@@ -37,6 +37,6 @@ ax.plot(
     markersize=1,
     alpha=alpha,
 )
-vals = spline.eval(ts)
+vals = spline(ts)
 ax.plot(vals[:, 0], vals[:, 1], "-", color="forestgreen", linewidth=1, alpha=alpha)
 plt.show()

--- a/examples/plot_celegans.py
+++ b/examples/plot_celegans.py
@@ -91,14 +91,14 @@ t = np.linspace(0, M - 1, 500)
 
 def _update2(i):
     mpl_img.set_array(stack[i])
-    vals = splines[i].eval(t)
+    vals = splines[i](t)
     mpl_line.set_data(vals[:, 1], vals[:, 0])
     return (mpl_img, mpl_line)
 
 
 fig, ax = plt.subplots(figsize=(7, 3))
 mpl_img = ax.imshow(stack[0], cmap="Greys_r")
-vals = splines[0].eval(t)
+vals = splines[0](t)
 (mpl_line,) = ax.plot(vals[:, 1], vals[:, 0])
 ax.set(xlim=(0, stack.shape[2]), ylim=(0, stack.shape[1]))
 animation = matplotlib.animation.FuncAnimation(fig, _update2, len(stack), interval=100, blit=True)
@@ -110,14 +110,14 @@ plt.show()
 # To focus on the undulating motion, we translate the splines to their center of mass and rotate them to align horizontally.
 
 for spline in splines:
-    start_point = np.squeeze(spline.eval(0))
-    stop_point = np.squeeze(spline.eval(spline.M - 1))
+    start_point = np.squeeze(spline(0))
+    stop_point = np.squeeze(spline(spline.M - 1))
     angle = np.arctan2(*(stop_point - start_point))
     c = np.cos(angle)
     s = np.sin(angle)
     rot_matrix = np.array([[c, -s], [s, c]])
     spline.rotate(rot_matrix)
-    com = np.mean(spline.eval(t), axis=0)
+    com = np.mean(spline(t), axis=0)
     spline.translate(-com)
 
 # %%
@@ -125,7 +125,7 @@ for spline in splines:
 
 
 def _update3(i):
-    vals = splines[i].eval(t)
+    vals = splines[i](t)
     curvature = splines[i].curvature(t)
     normals = splines[i].normal(t)
     comb = vals + d * curvature[:, np.newaxis] * normals
@@ -137,7 +137,7 @@ def _update3(i):
 
 
 fig, ax = plt.subplots(figsize=(7, 3))
-vals = splines[0].eval(t)
+vals = splines[0](t)
 curvature = splines[0].curvature(t)
 normals = splines[0].normal(t)
 d = 50

--- a/examples/plot_curvature_combs.py
+++ b/examples/plot_curvature_combs.py
@@ -28,7 +28,7 @@ t = np.linspace(0, M - 1, 1000)
 # To plot the curvature comb, we need to compute the spline's values, curvature, and normal vectors at each t.
 # Normal vectors are unit vectors perpendicular to the spline at each point.
 
-vals = spline.eval(t)
+vals = spline(t)
 
 curvature = spline.curvature(t)
 normals = spline.normal(t)

--- a/examples/plot_dendrite.py
+++ b/examples/plot_dendrite.py
@@ -133,7 +133,7 @@ spline.fit(skeleton_points)
 
 # Creat meshes for the spline and the knots of the spline
 t = np.linspace(0, M - 1, M * 15)
-spline_mesh = pv.MultipleLines(points=spline.eval(t))
+spline_mesh = pv.MultipleLines(points=spline(t))
 knots_point_cloud = pv.PolyData(spline.knots)
 
 # Prepare segmentation mesh
@@ -159,7 +159,7 @@ plotter.show()
 # of the spline (i.e. the vector pointing in the local direction of the spline).
 
 # Compute derivative vectors along the spline
-deriv = spline.eval(t, derivative=1)
+deriv = spline(t, derivative=1)
 
 # %%
 # **Compute the first normal vector**
@@ -206,7 +206,7 @@ plotter.show()
 # Finally, we interpolate pixel values from the original image along the computed normal planes.
 
 # Centers of the normal planes
-spline_coordinates = spline.eval(t)
+spline_coordinates = spline(t)
 
 # Coefficients for scaling the normal vectors
 half_window_size = 25

--- a/examples/plot_distance.py
+++ b/examples/plot_distance.py
@@ -16,8 +16,8 @@ import splinebox
 
 
 def plot_splines(spline1, spline2, t_min=None, s_min=None):
-    vals1 = spline1.eval(np.linspace(0, spline1.M, 1000))
-    vals2 = spline2.eval(np.linspace(0, spline2.M, 1000))
+    vals1 = spline1(np.linspace(0, spline1.M, 1000))
+    vals2 = spline2(np.linspace(0, spline2.M, 1000))
     knots1 = spline1.knots
     knots2 = spline2.knots
 
@@ -27,8 +27,8 @@ def plot_splines(spline1, spline2, t_min=None, s_min=None):
     plt.scatter(knots2[:, 1], knots2[:, 0])
 
     if t_min is not None and s_min is not None:
-        point1 = spline1.eval(t_min)
-        point2 = spline2.eval(s_min)
+        point1 = spline1(t_min)
+        point2 = spline2(s_min)
         plt.plot([point1[1], point2[1]], [point1[0], point2[0]], color="k", linestyle="--")
 
     plt.gca().set_aspect("equal", "box")
@@ -76,8 +76,8 @@ plot_splines(spline1, spline2)
 
 t = np.linspace(0, spline1.M, 5)
 s = np.linspace(0, spline2.M, 5)
-vals1 = spline1.eval(t)
-vals2 = spline2.eval(s)
+vals1 = spline1(t)
+vals2 = spline2(s)
 distance_vectors = vals1[:, np.newaxis] - vals2[np.newaxis, :]
 distances = np.linalg.norm(distance_vectors, axis=-1)
 indices = np.unravel_index(np.argmin(distances), distances.shape)
@@ -92,8 +92,8 @@ plot_splines(spline1, spline2, t_min, s_min)
 
 
 def distance(parameters):
-    val1 = spline1.eval(parameters[0])
-    val2 = spline2.eval(parameters[1])
+    val1 = spline1(parameters[0])
+    val2 = spline2(parameters[1])
     return np.linalg.norm(val1 - val2)
 
 

--- a/examples/plot_example1.py
+++ b/examples/plot_example1.py
@@ -38,7 +38,7 @@ for i, (name, basis_function) in enumerate(
     M = len(knots)
     curve = splinebox.spline_curves.Spline(M, basis_function, True)
     curve.knots = knots
-    discreteContour = curve.eval(t)
+    discreteContour = curve(t)
 
     axes[i // n, i % n].scatter(knots[:, 0], knots[:, 1])
     axes[i // n, i % n].plot(discreteContour[:, 0], discreteContour[:, 1])

--- a/examples/plot_frame.py
+++ b/examples/plot_frame.py
@@ -56,7 +56,7 @@ bishop_frame = spline.moving_frame(t, method="bishop")
 # The Frenet-Serret frame (left) visibly twists along the curve, while the Bishop frame (right) avoids this twist.
 
 # Create a PyVista mesh for the curve
-spline_mesh = pyvista.MultipleLines(points=spline.eval(t))
+spline_mesh = pyvista.MultipleLines(points=spline(t))
 
 # Add vectors to the mesh for visualization
 spline_mesh["frenet0"] = frenet_frame[:, 0] * 0.2

--- a/examples/plot_peptides.py
+++ b/examples/plot_peptides.py
@@ -64,7 +64,7 @@ initial_spline = splinebox.spline_curves.Spline(M=M, basis_function=basis_functi
 initial_spline.fit(skeleton_points)
 
 t = np.linspace(0, M - 1, M * 100)
-initial_vals = initial_spline.eval(t)
+initial_vals = initial_spline(t)
 initial_knots = initial_spline.knots
 
 plt.imshow(img, cmap="afmhot")
@@ -79,10 +79,10 @@ plt.show()
 
 def loss_function(control_points, alpha):
     spline.control_points = control_points.reshape((-1, 2))
-    coords = spline.eval(t)
+    coords = spline(t)
     pixel_values = scipy.ndimage.map_coordinates(img, coords.T)
     image_energy = np.mean(pixel_values)
-    internal_energy = np.mean(spline.eval(t, derivative=2) ** 2)
+    internal_energy = np.mean(spline(t, derivative=2) ** 2)
     energy = -1 * image_energy + alpha * internal_energy
     return energy
 
@@ -97,7 +97,7 @@ scipy.optimize.minimize(
     tol=0.01,
 )
 
-vals = spline.eval(t)
+vals = spline(t)
 knots = spline.knots
 
 plt.figure()
@@ -117,7 +117,7 @@ total_length = spline.arc_length()
 lengths = np.linspace(0, total_length, 200)
 t = spline.arc_length_to_parameter(lengths)
 
-vals = spline.eval(t)
+vals = spline(t)
 curvature = spline.curvature(t)
 normals = spline.normal(t)
 

--- a/examples/plot_performance_comparison_with_scipy.py
+++ b/examples/plot_performance_comparison_with_scipy.py
@@ -62,7 +62,7 @@ for closed in [True, False]:
                 for nt in [10, 100, 1000, 10000]:
                     t = np.linspace(0, M if closed else M - 1, nt)
                     start_eval = time.perf_counter_ns()
-                    spline.eval(t)
+                    spline(t)
                     stop_eval = time.perf_counter_ns()
 
                     if repetition != 0:

--- a/examples/plot_sin.py
+++ b/examples/plot_sin.py
@@ -33,7 +33,7 @@ spline.fit(values)
 # To plot the spline we evaluate it at finely spaced parameter values.
 
 ts = np.linspace(0, M - 1, 1000)
-spline_y = spline.eval(ts)
+spline_y = spline(ts)
 spline_x = np.linspace(x.min(), x.max(), len(ts))
 
 plt.scatter(x, values, label="data")

--- a/examples/plot_splinebox_vs_scipy_coin.py
+++ b/examples/plot_splinebox_vs_scipy_coin.py
@@ -55,7 +55,7 @@ spline = splinebox.Spline(M=M, basis_function=splinebox.B3(), closed=True)
 spline.fit(contour)
 
 ts = np.linspace(0, M, 100)
-splinebox_vals = spline.eval(ts)
+splinebox_vals = spline(ts)
 splinebox_control_points = spline.control_points
 
 plt.imshow(img, cmap="gray", alpha=0.5)

--- a/examples/plot_splinebox_vs_scipy_line.py
+++ b/examples/plot_splinebox_vs_scipy_line.py
@@ -68,7 +68,7 @@ t = np.linspace(0, M - 1, M * 50)
 # %%
 # In order to compar the fitted spline to the intial one,
 # we save it's positions and knots for plotting later on.
-initial_vals = spline.eval(t)
+initial_vals = spline(t)
 initial_knots = spline.knots
 
 
@@ -86,7 +86,7 @@ initial_knots = spline.knots
 
 def loss_function_splinebox(control_points, alpha):
     spline.control_points = control_points.reshape((-1, 2))
-    coordinates = spline.eval(t)
+    coordinates = spline(t)
     image_energy = np.mean(interpolator(coordinates[:, 0], coordinates[:, 1], grid=False))
     internal_energy = spline.curvilinear_reparametrization_energy()
     return image_energy + alpha * internal_energy
@@ -104,7 +104,7 @@ scipy.optimize.minimize(loss_function_splinebox, initial_control_points.flatten(
 # Plot the Results (splinebox)
 # ----------------------------
 # Finally, we plot the initial and fitted splines for comparison.
-fitted_vals = spline.eval(t)
+fitted_vals = spline(t)
 fitted_knots = spline.knots
 
 fix, axes = plt.subplots(2, 1, sharex=True, sharey=True)
@@ -132,11 +132,11 @@ plt.show()
 k = 3
 # The parameter value for the knots
 t_knots = np.arange(M)
-spline = scipy.interpolate.make_interp_spline(t_knots, initial_knots, k=3, bc_type="natural")
+scipy_spline = scipy.interpolate.make_interp_spline(t_knots, initial_knots, k=3, bc_type="natural")
 
 # Save initial values for comparison
-initial_vals = spline(t)
-initial_knots = spline(spline.t)[k:-k]
+initial_vals = scipy_spline(t)
+initial_knots = scipy_spline(scipy_spline.t)[k:-k]
 
 
 # %%
@@ -144,12 +144,12 @@ initial_knots = spline(spline.t)[k:-k]
 # ----------------------------------
 # Since scipy does not have a built-in curvilinear reparametrization energy, we calculate it manually.
 def loss_function_scipy(control_points, alpha):
-    spline.c = control_points.reshape((-1, 2))
-    coordinates = spline(t)
+    scipy_spline.c = control_points.reshape((-1, 2))
+    coordinates = scipy_spline(t)
     image_energy = np.mean(interpolator(coordinates[:, 0], coordinates[:, 1], grid=False))
 
     # Compute internal energy (curvilinear reparametrization)
-    derivative = spline.derivative()
+    derivative = scipy_spline.derivative()
     integral = scipy.integrate.quad(lambda t: np.linalg.norm(derivative(t)), 0, M - 1)
     length = integral[0]
     c = (length / M) ** 2
@@ -162,15 +162,15 @@ def loss_function_scipy(control_points, alpha):
 # %%
 # Fit the Spline (scipy)
 # ----------------------
-initial_control_points = spline.c
+initial_control_points = scipy_spline.c
 scipy.optimize.minimize(loss_function_scipy, initial_control_points.flatten(), args=(500,))
 
 # %%
 # Plot the Results (scipy)
 # ------------------------
 # Finally, we plot the initial and fitted splines for the scipy result.
-fitted_vals = spline(t)
-fitted_knots = spline(spline.t[k:-k])
+fitted_vals = scipy_spline(t)
+fitted_knots = scipy_spline(scipy_spline.t[k:-k])
 
 fix, axes = plt.subplots(2, 1, sharex=True, sharey=True)
 axes[0].imshow(img, cmap="gray")

--- a/src/splinebox/basis_functions.py
+++ b/src/splinebox/basis_functions.py
@@ -47,7 +47,7 @@ class BasisFunction:
             and other.support == self.support
         )
 
-    def eval(self, t, derivative=0):
+    def __call__(self, t, derivative=0):
         """
         Evaluate the function at position(s) `t`.
 
@@ -73,6 +73,14 @@ class BasisFunction:
             return self._derivative_2(t)
         else:
             raise ValueError(f"derivative has to be 0, 1, or 2 not {derivative}")
+
+    def eval(self, t, derivative=0):
+        warnings.warn(
+            "`basis_function.eval(t)` is deprecated and will be removed in v1. Use `basis_function(t)` instead.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+        return self(t, derivative=derivative)
 
     def _func(self, t):
         raise NotImplementedError(BasisFunction._unimplemented_message)
@@ -683,7 +691,7 @@ class CubicHermite(BasisFunction):
     please see the documentation for :class:`splinebox.basis_functions.BasisFunction`.
 
     **Note**: This is basis function is a :class:`multigenerator <splinebox.basis_functions.BasisFunction>` and
-    :func:`eval <splinebox.basis_functions.BasisFunction.eval>` returns two values.
+    :func:`__call__ <splinebox.basis_functions.BasisFunction.__call__>` returns two values.
     """
 
     def __init__(self):
@@ -898,7 +906,7 @@ class ExponentialHermite(BasisFunction):
     please see the documentation for :class:`splinebox.basis_functions.BasisFunction`.
 
     **Note**: This is basis function is a :class:`multigenerator <splinebox.basis_functions.BasisFunction>` and
-    :func:`eval <splinebox.basis_functions.BasisFunction.eval>` returns two values.
+    :func:`__call__ <splinebox.basis_functions.BasisFunction.__call__>` returns two values.
     """
 
     def __init__(self, M):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -152,7 +152,7 @@ def derivative(request):
 
 
 @pytest.fixture(params=[1.5, np.array(0.0), np.linspace(0, 10, 1000)])
-def eval_positions(request):
+def call_positions(request):
     return request.param
 
 
@@ -204,7 +204,7 @@ def is_spline():
 def is_interpolating(is_spline):
     def _is_interpolating(obj):
         basis_function = obj.basis_function if is_spline(obj) else obj
-        return np.allclose(basis_function.eval(0), 1)
+        return np.allclose(basis_function(0), 1)
 
     return _is_interpolating
 

--- a/tests/test_basis_functions.py
+++ b/tests/test_basis_functions.py
@@ -5,11 +5,11 @@ import pytest
 import splinebox.basis_functions
 
 
-def test_base_class_eval(derivative):
+def test_base_class_call(derivative):
     basis_function = splinebox.basis_functions.BasisFunction(False, 2)
     x = np.arange(10)
     with pytest.raises(NotImplementedError):
-        basis_function.eval(x, derivative=derivative)
+        basis_function(x, derivative=derivative)
 
 
 def test_base_class_filters_and_refinement_mask():
@@ -52,13 +52,13 @@ def test_refinement_mask(basis_function, is_locally_refinable, request):
         refinement_factor = max(math.floor(len(mask) / 2), 2)
         half_support = basis_function.support / 2
         t = np.linspace(0, basis_function.support, 100) * refinement_factor
-        expected = basis_function.eval((t / refinement_factor) - half_support)
+        expected = basis_function((t / refinement_factor) - half_support)
         result = np.zeros(len(t))
         # plt.plot(t, expected, label="expected")
         # if isinstance(basis_function, splinebox.basis_functions.Exponential):
         #     basis_function.M *= refinement_factor
         for i in range(len(mask)):
-            intermediate = mask[i] * basis_function.eval(t - i - half_support)
+            intermediate = mask[i] * basis_function(t - i - half_support)
             # plt.plot(t, intermediate)
             result += intermediate
         # plt.plot(t, result, label="results")
@@ -70,15 +70,15 @@ def test_refinement_mask(basis_function, is_locally_refinable, request):
             basis_function.refinement_mask()
 
 
-def test_eval_derivative_argument(basis_function, not_differentiable_twice):
+def test_call_derivative_argument(basis_function, not_differentiable_twice):
     t = np.linspace(-1, 1, 20)
     # Check that 0, 1, 2 don't raise errors
     for derivative in range(3):
         if derivative == 2 and not_differentiable_twice(basis_function):
             continue
-        basis_function.eval(t, derivative=derivative)
+        basis_function(t, derivative=derivative)
     with pytest.raises(ValueError):
-        basis_function.eval(t, derivative=4)
+        basis_function(t, derivative=4)
 
 
 def test_derivatives(basis_function, derivative, not_differentiable_twice):
@@ -87,7 +87,7 @@ def test_derivatives(basis_function, derivative, not_differentiable_twice):
 
     support = basis_function.support
     x = np.linspace(-support / 2 - 1, support / 2 + 1, 100000)
-    y = basis_function.eval(x, derivative=derivative - 1)
+    y = basis_function(x, derivative=derivative - 1)
 
     dx = np.diff(x)
     dy = np.diff(y)
@@ -96,13 +96,13 @@ def test_derivatives(basis_function, derivative, not_differentiable_twice):
     if not_differentiable_twice(basis_function) and derivative == 2:
         # B1, CubicHermite, and ExponentialHermite basis functions are not differentiable twice.
         with pytest.raises(RuntimeError):
-            basis_function.eval(x[:-1] + dx / 2, derivative=2)
+            basis_function(x[:-1] + dx / 2, derivative=2)
     else:
         # Check where the estimated derivative is close to the
         # derivative value returned by the method
         close = np.isclose(
             estimated_derivative,
-            basis_function.eval(x[:-1] + dx / 2, derivative=derivative),
+            basis_function(x[:-1] + dx / 2, derivative=derivative),
         )
 
         # Since the basis functions are not continously differentiable, the
@@ -125,7 +125,7 @@ def test_partition_of_unity(basis_function):
     x = np.linspace(0, 1, 10000)
     summed = np.zeros_like(x)
     for k in range(-support, support):
-        vals = basis_function.eval(x - k)
+        vals = basis_function(x - k)
         if basis_function.multigenerator:
             vals = vals[0]
         if vals.ndim == 2:


### PR DESCRIPTION
Deprecate the `eval` methods of the `Spline` and `BasisFunction` classes and replace them with `__call__` methods.
See issue #39.