### PR TITLE
Float moving frame

### DIFF
--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -778,6 +778,9 @@ def test_moving_frame(initialized_spline_curve, not_differentiable_twice):
         else:
             frame = spline.moving_frame(t, method="frenet")
 
+            # Check that you can pass a float value
+            assert frame[5] == spline.moving_frame(t[5], method="frenet")
+
             # Check that they are unit vectors
             assert np.allclose(np.linalg.norm(frame, axis=-1), 1)
 
@@ -802,6 +805,9 @@ def test_moving_frame(initialized_spline_curve, not_differentiable_twice):
         with pytest.raises(ValueError):
             # Non-orthogonal initial vector
             frame = spline.moving_frame(t, method="bishop", initial_vector=np.ones(3))
+
+            # Check that you can pass a float value
+            assert frame[5] == spline.moving_frame(t[5], method="bishop", initial_vector=np.ones(3))
 
         initial_vector = np.zeros(3)
         tangent = spline(t[0], derivative=1)

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -779,7 +779,7 @@ def test_moving_frame(initialized_spline_curve, not_differentiable_twice):
             frame = spline.moving_frame(t, method="frenet")
 
             # Check that you can pass a float value
-            assert frame[5] == spline.moving_frame(t[5], method="frenet")
+            assert np.allclose(frame[5], spline.moving_frame(t[5], method="frenet"))
 
             # Check that they are unit vectors
             assert np.allclose(np.linalg.norm(frame, axis=-1), 1)
@@ -807,7 +807,7 @@ def test_moving_frame(initialized_spline_curve, not_differentiable_twice):
             frame = spline.moving_frame(t, method="bishop", initial_vector=np.ones(3))
 
             # Check that you can pass a float value
-            assert frame[5] == spline.moving_frame(t[5], method="bishop", initial_vector=np.ones(3))
+            assert np.allclose(frame[5], spline.moving_frame(t[5], method="bishop", initial_vector=np.ones(3)))
 
         initial_vector = np.zeros(3)
         tangent = spline(t[0], derivative=1)


### PR DESCRIPTION
Allows a single value input to the `moving_frame` method like a float or an int.
Fixes issue #51.