### PR TITLE
Arc length to parameter int

### DIFF
--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -550,7 +550,7 @@ class Spline:
         if not isinstance(s, np.ndarray):
             s = np.array([s])
         sort_indices = np.argsort(s)
-        results = np.zeros_like(s)
+        results = np.zeros_like(s, dtype=float)
 
         current_value = 0
         lower_bound = 0

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -242,6 +242,13 @@ def test_arc_length_to_parameter():
 
     assert np.allclose(results, expected, atol=1e-3, rtol=0)
 
+    # Check that it works with an array of integer inputs
+    ls = np.arange(0, int(2 * np.pi), dtype=int)
+    expected = ls / 2 / np.pi * M
+    results = spline.arc_length_to_parameter(ls, atol=atol)
+    assert np.allclose(results, expected, atol=1e-3, rtol=0)
+    results = spline.arc_length_to_parameter(ls, atol=atol)
+
     # Create a sawtooth spline
     M = 7
     basis_function = splinebox.basis_functions.B1()


### PR DESCRIPTION
Fixes the fact that `arc_length_to_parameter` returns an int array of parameters when the input lengths are of type int.
This resolves issue #52.