### PR TITLE
Remove eval

### DIFF
--- a/src/splinebox/basis_functions.py
+++ b/src/splinebox/basis_functions.py
@@ -137,14 +137,6 @@ class BasisFunction:
         else:
             raise ValueError(f"derivative has to be 0, 1, or 2 not {derivative}")
 
-    def eval(self, t, derivative=0):
-        warnings.warn(
-            "`basis_function(t)` is deprecated and will be removed in v1. Use `basis_function(t)` instead.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return self(t, derivative=derivative)
-
     def _func(self, t):
         raise NotImplementedError(BasisFunction._unimplemented_message)
 

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -1198,17 +1198,6 @@ class Spline:
         value = np.matmul(basis_function_values, self.control_points)
         return np.squeeze(value)
 
-    def eval(self, t, derivative=0):
-        """
-        eval is deprecated use :meth:`splinebox.spline_curves.Spline.__call__` instead.
-        """
-        warnings.warn(
-            "`spline.eval(t)` is deprecated and will be removed in v1 use `spline(t)` instead.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return self(t, derivative=derivative)
-
     def _convert_to_array(self, t):
         """
         Helper function that converts the a function input


### PR DESCRIPTION
Removes the deprecated `eval` methods from the `BasisFunction` and `Spline` classes.
Closes #39.