### PR TITLE
Stop ignoring shadowed python buildin eval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ select = [
 ]
 ignore = [
     "E501", # line too long. let black handle this
-    "A003", # shadowing of a Python builtin
 ]
 
 exclude = [


### PR DESCRIPTION
Remove ruff ignore for shadowing python build-ins. Not necessary anymore since `eval` was removed.