### PR TITLE
Add optional spherical caps to spline meshes

### DIFF
--- a/examples/plot_mesh.py
+++ b/examples/plot_mesh.py
@@ -168,4 +168,5 @@ mesh.explode(factor=0.5).plot(show_edges=True)
 # Tips
 # ----
 # * Save meshes for visualization in ParaView using :code:`mesh.save("mesh.vtk")`.
-# * Surface meshes are open by default. Use the :code:`cap_ends` keyword in :meth:`splinebox.spline_curves.Spline.mesh()` to close them.
+# * Surface meshes are open by default. Use :code:`cap_ends="flat"` for planar end caps or
+#   :code:`cap_ends="sphere"` for hemispherical end caps in :meth:`splinebox.spline_curves.Spline.mesh()`.

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -1147,7 +1147,10 @@ class Spline:
         if self.control_points.ndim != 2 or self.control_points.shape[1] != 3:
             raise NotImplementedError("Meshes are only implemented for splines in 3D.")
         cap_ends = self._normalize_cap_ends(cap_ends)
-        t = np.arange(0, self.M if self.closed else self.M - 1 + step_t, step_t)
+        end_t = self.M if self.closed else self.M - 1
+        t = np.arange(0, end_t, step_t)
+        if len(t) == 0 or not np.isclose(t[-1], end_t):
+            t = np.append(t, end_t)
         if radius is None or radius == 0:
             points = self(t)
             connectivity = np.stack((np.arange(len(points)), np.arange(len(points)) + 1), axis=-1)

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -1124,9 +1124,9 @@ class Spline:
         -----
         - Surface meshes are useful for visualization, while volume meshes are
           typically used in simulations and finite element analysis.
-                - For open splines, capping the ends (`cap_ends="flat"` or
-                    `cap_ends="sphere"`) creates closed surfaces, which may be useful for
-                    some applications.
+        - For open splines, capping the ends (`cap_ends="flat"` or
+          `cap_ends="sphere"`) creates closed surfaces, which may be useful for
+          some applications.
         - The Bishop frame is recommended for curves with inflection points or
           straight segments where the Frenet frame is undefined.
         - When radius is callable, the Bishop frame is recommend to avoid "drift" of the

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -1146,7 +1146,10 @@ class Spline:
         """
         if self.control_points.ndim != 2 or self.control_points.shape[1] != 3:
             raise NotImplementedError("Meshes are only implemented for splines in 3D.")
-        cap_ends = self._normalize_cap_ends(cap_ends)
+        if mesh_type == "surface" and not self.closed:
+            cap_ends = self._normalize_cap_ends(cap_ends)
+        else:
+            cap_ends = None
         end_t = self.M if self.closed else self.M - 1
         t = np.arange(0, end_t, step_t)
         if len(t) == 0 or not np.isclose(t[-1], end_t):

--- a/src/splinebox/spline_curves.py
+++ b/src/splinebox/spline_curves.py
@@ -1048,7 +1048,7 @@ class Spline:
         step_t=0.1,
         step_angle=5,
         mesh_type="surface",
-        cap_ends=False,
+        cap_ends=None,
         frame="bishop",
         initial_vector=None,
     ):
@@ -1084,9 +1084,15 @@ class Spline:
             - "volume": A volume mesh with tetrahedral cells.
 
             Default is "surface".
-        cap_ends : bool, optional
-            If True, the ends of an open surface mesh are capped with orthogonal
-            planes. Ignored for closed splines or volume meshes. Default is False.
+        cap_ends : {None, "flat", "sphere"}, optional
+            Controls how the ends of an open surface mesh are capped:
+
+            - None leaves the ends open.
+            - "flat" creates orthogonal planar caps.
+            - "sphere" creates hemispherical caps.
+
+            Closed splines and volume meshes ignore this parameter. `False` is
+            accepted as a deprecated alias for `None`.
         frame : str, optional
             The frame to use for orientation of the mesh:
             - "frenet": Uses the Frenet-Serret frame.
@@ -1118,8 +1124,9 @@ class Spline:
         -----
         - Surface meshes are useful for visualization, while volume meshes are
           typically used in simulations and finite element analysis.
-        - For open splines, capping the ends (`cap_ends=True`) creates closed surfaces,
-          which may be useful for some applications.
+                - For open splines, capping the ends (`cap_ends="flat"` or
+                    `cap_ends="sphere"`) creates closed surfaces, which may be useful for
+                    some applications.
         - The Bishop frame is recommended for curves with inflection points or
           straight segments where the Frenet frame is undefined.
         - When radius is callable, the Bishop frame is recommend to avoid "drift" of the
@@ -1139,6 +1146,7 @@ class Spline:
         """
         if self.control_points.ndim != 2 or self.control_points.shape[1] != 3:
             raise NotImplementedError("Meshes are only implemented for splines in 3D.")
+        cap_ends = self._normalize_cap_ends(cap_ends)
         t = np.arange(0, self.M if self.closed else self.M - 1 + step_t, step_t)
         if radius is None or radius == 0:
             points = self(t)
@@ -1159,28 +1167,56 @@ class Spline:
                 phiphi = phiphi.flatten()
                 centers = self(tt.flatten())
                 rr = _radius(tt, phiphi)
-                normals = self.normal(t, frame=frame, initial_vector=initial_vector)
+                frame_vectors = self.moving_frame(t, method=frame, initial_vector=initial_vector)
+                tangents = frame_vectors[:, 0]
+                normals = frame_vectors[:, 1:]
 
                 n_angles = len(phi)
                 n_t = len(t)
-                normals = (
+                normal_vectors = (
                     np.repeat(normals[:, 0], n_angles, axis=0) * np.sin(np.deg2rad(phiphi))[:, np.newaxis]
                     + np.repeat(normals[:, 1], n_angles, axis=0) * np.cos(np.deg2rad(phiphi))[:, np.newaxis]
                 )
 
-                points = centers + rr[:, np.newaxis] * normals
+                points = centers + rr[:, np.newaxis] * normal_vectors
                 n_points = len(points)
                 connectivity = self._surface_mesh_connectivity(self.closed, n_angles, n_t, n_points)
-                if cap_ends and not self.closed:
-                    points = np.concatenate((centers[0].reshape((1, -1)), points, centers[-1].reshape((1, -1))), axis=0)
-                    start_connectivity = np.zeros((n_angles, 3), dtype=int)
-                    start_connectivity[:, 1] = np.arange(1, n_angles + 1)
-                    start_connectivity[:, 2] = np.roll(start_connectivity[:, 1], -1)
-                    end_connectivity = np.zeros((n_angles, 3), dtype=int)
-                    end_connectivity[:, 0] = n_points + 1
-                    end_connectivity[:, 1] = np.arange(n_points, n_points - n_angles, -1)
-                    end_connectivity[:, 2] = np.roll(end_connectivity[:, 1], -1)
-                    connectivity = np.concatenate((start_connectivity, connectivity + 1, end_connectivity))
+                if cap_ends is not None and not self.closed:
+                    body_points = points
+                    start_ring = np.arange(n_angles)
+                    end_ring = np.arange(n_points - n_angles, n_points)
+
+                    if cap_ends == "flat":
+                        start_center_index = n_points
+                        end_center_index = n_points + 1
+                        cap_points = np.stack((centers[0], centers[-1]), axis=0)
+                        start_connectivity = self._surface_cap_pole_connectivity(
+                            start_ring, start_center_index, reverse=False
+                        )
+                        end_connectivity = self._surface_cap_pole_connectivity(end_ring, end_center_index, reverse=True)
+                        points = np.concatenate((points, cap_points), axis=0)
+                        connectivity = np.concatenate((connectivity, start_connectivity, end_connectivity), axis=0)
+                    elif cap_ends == "sphere":
+                        start_points, start_connectivity = self._surface_cap_sphere(
+                            center=centers[0],
+                            axis=-tangents[0],
+                            equator_points=body_points[start_ring],
+                            equator_indices=start_ring,
+                            step_angle=step_angle,
+                            start_index=n_points,
+                            reverse=False,
+                        )
+                        end_points, end_connectivity = self._surface_cap_sphere(
+                            center=centers[-1],
+                            axis=tangents[-1],
+                            equator_points=body_points[end_ring],
+                            equator_indices=end_ring,
+                            step_angle=step_angle,
+                            start_index=n_points + len(start_points),
+                            reverse=True,
+                        )
+                        points = np.concatenate((points, start_points, end_points), axis=0)
+                        connectivity = np.concatenate((connectivity, start_connectivity, end_connectivity), axis=0)
 
             elif mesh_type == "volume":
                 phiphi, tt = np.meshgrid(phi, t)
@@ -1209,6 +1245,79 @@ class Spline:
                 connectivity = self._volume_mesh_connectivity(self.closed, n_angles, n_t, n_points)
 
         return points, connectivity
+
+    @staticmethod
+    def _normalize_cap_ends(cap_ends):
+        if cap_ends is None:
+            return None
+        if isinstance(cap_ends, (bool, np.bool_)):
+            if not cap_ends:
+                warnings.warn(
+                    "`cap_ends=False` is deprecated, use `cap_ends=None` instead.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+                return None
+            raise ValueError("`cap_ends=True` is no longer supported, use `cap_ends='flat'` instead.")
+        if cap_ends in ("flat", "sphere"):
+            return cap_ends
+        raise ValueError("cap_ends must be None, 'flat', or 'sphere'.")
+
+    @staticmethod
+    def _surface_cap_ring_connectivity(ring_a, ring_b, reverse=False):
+        connectivity = np.zeros((2 * len(ring_a), 3), dtype=int)
+        face = 0
+        for j in range(len(ring_a)):
+            next_j = (j + 1) % len(ring_a)
+            if reverse:
+                connectivity[face] = [ring_a[j], ring_b[next_j], ring_b[j]]
+                face += 1
+                connectivity[face] = [ring_a[j], ring_a[next_j], ring_b[next_j]]
+            else:
+                connectivity[face] = [ring_a[j], ring_b[j], ring_b[next_j]]
+                face += 1
+                connectivity[face] = [ring_a[j], ring_b[next_j], ring_a[next_j]]
+            face += 1
+        return connectivity
+
+    @staticmethod
+    def _surface_cap_pole_connectivity(ring, pole_index, reverse=False):
+        connectivity = np.zeros((len(ring), 3), dtype=int)
+        connectivity[:, 0] = pole_index
+        if reverse:
+            connectivity[:, 1] = np.roll(ring, -1)
+            connectivity[:, 2] = ring
+        else:
+            connectivity[:, 1] = ring
+            connectivity[:, 2] = np.roll(ring, -1)
+        return connectivity
+
+    @classmethod
+    def _surface_cap_sphere(cls, center, axis, equator_points, equator_indices, step_angle, start_index, reverse=False):
+        equator_vectors = equator_points - center[np.newaxis, :]
+        radius = np.mean(np.linalg.norm(equator_vectors, axis=1))
+        latitude_angles = np.arange(step_angle, 90, step_angle)
+
+        points = []
+        connectivity = []
+        previous_ring = equator_indices
+        next_index = start_index
+
+        for angle in latitude_angles:
+            angle = np.deg2rad(angle)
+            ring_points = center + np.cos(angle) * equator_vectors + np.sin(angle) * radius * axis[np.newaxis, :]
+            ring_indices = np.arange(next_index, next_index + len(equator_indices))
+            points.append(ring_points)
+            connectivity.append(cls._surface_cap_ring_connectivity(previous_ring, ring_indices, reverse=reverse))
+            previous_ring = ring_indices
+            next_index += len(equator_indices)
+
+        pole_index = next_index
+        pole_point = center + radius * axis
+        points.append(pole_point[np.newaxis, :])
+        connectivity.append(cls._surface_cap_pole_connectivity(previous_ring, pole_index, reverse=reverse))
+
+        return np.concatenate(points, axis=0), np.concatenate(connectivity, axis=0)
 
     @staticmethod
     @numba.jit(nopython=True, nogil=True, cache=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,7 +325,7 @@ def mesh_type(request):
     return request.param
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=[None, "flat", "sphere"])
 def cap_ends(request):
     return request.param
 

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -957,6 +957,16 @@ def test_spherical_caps_add_more_geometry_than_flat_caps():
     assert len(sphere_connectivity) > len(flat_connectivity)
 
 
+def test_flat_caps_use_exact_open_spline_endpoints_when_step_t_does_not_divide_range():
+    spline = splinebox.spline_curves.Spline(M=4, basis_function=splinebox.basis_functions.B3(), closed=False)
+    spline.knots = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.5, 0.0], [3.0, 0.5, 0.5]])
+
+    points, _ = spline.mesh(radius=0.2, step_t=0.4, step_angle=30, cap_ends="flat")
+
+    assert np.allclose(points[-2], spline(0))
+    assert np.allclose(points[-1], spline(spline.M - 1))
+
+
 def test_protected_spline_attributes(spline_curve, coeff_gen, basis_function):
     # spline = splinebox.spline_curves.Spline(M=4, basis_function=splinebox.basis_functions.B1(), closed=True)
     spline = spline_curve

--- a/tests/test_spline_curves.py
+++ b/tests/test_spline_curves.py
@@ -899,7 +899,7 @@ def test_mesh(
         # Check that all points are part of at least one element
         assert np.all(np.arange(len(points)) == np.sort(np.unique(connectivity)))
 
-        if mesh_type == "surface" and (cap_ends or spline.closed):
+        if mesh_type == "surface" and (cap_ends is not None or spline.closed):
             # Compute the Euler characteristic to check that the mesh is closed
 
             # Number of verices
@@ -921,9 +921,40 @@ def test_mesh(
             elif spline.closed:
                 # toroidal polyhedra have Euler characteristic 0
                 assert V + F - E == 0
-            elif cap_ends:
+            elif cap_ends is not None:
                 # spherical polyhedra have Euler characteristic 2
                 assert V + F - E == 2
+
+
+def test_mesh_cap_ends_false_alias_matches_none():
+    spline = splinebox.spline_curves.Spline(M=4, basis_function=splinebox.basis_functions.B3(), closed=False)
+    spline.knots = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.5, 0.0], [3.0, 0.5, 0.5]])
+
+    points_none, connectivity_none = spline.mesh(radius=0.2, step_t=0.5, step_angle=30, cap_ends=None)
+    with pytest.warns(DeprecationWarning, match="cap_ends=False"):
+        points_false, connectivity_false = spline.mesh(radius=0.2, step_t=0.5, step_angle=30, cap_ends=False)
+
+    assert np.allclose(points_none, points_false)
+    assert np.array_equal(connectivity_none, connectivity_false)
+
+
+def test_mesh_cap_ends_true_raises_value_error():
+    spline = splinebox.spline_curves.Spline(M=4, basis_function=splinebox.basis_functions.B3(), closed=False)
+    spline.knots = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.5, 0.0], [3.0, 0.5, 0.5]])
+
+    with pytest.raises(ValueError, match="cap_ends='flat'"):
+        spline.mesh(radius=0.2, step_t=0.5, step_angle=30, cap_ends=True)
+
+
+def test_spherical_caps_add_more_geometry_than_flat_caps():
+    spline = splinebox.spline_curves.Spline(M=4, basis_function=splinebox.basis_functions.B3(), closed=False)
+    spline.knots = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.5, 0.0], [3.0, 0.5, 0.5]])
+
+    flat_points, flat_connectivity = spline.mesh(radius=0.2, step_t=0.5, step_angle=30, cap_ends="flat")
+    sphere_points, sphere_connectivity = spline.mesh(radius=0.2, step_t=0.5, step_angle=30, cap_ends="sphere")
+
+    assert len(sphere_points) > len(flat_points)
+    assert len(sphere_connectivity) > len(flat_connectivity)
 
 
 def test_protected_spline_attributes(spline_curve, coeff_gen, basis_function):


### PR DESCRIPTION
## Summary
- add explicit `cap_ends` modes for open surface meshes
- preserve flat end caps and add hemispherical `"sphere"` caps
- update mesh tests and example documentation for the new cap options

## Testing
- not run in PR creation step